### PR TITLE
[FIX] `create_graph()`: Fix bad return placement

### DIFF
--- a/experiments/eth-2nd-order-tx-subgraph-embedding/create_graph.py
+++ b/experiments/eth-2nd-order-tx-subgraph-embedding/create_graph.py
@@ -83,7 +83,6 @@ def create_graph(dataset, root):
             print('  ✅ SUCCESS → G\': {}'.format(G_prime))
             c_success += 1
             G = G_prime
-            return G
         except Exception as e:
             num_incorrect += 1
             print('  ❌ GRAPH MISMATCH')
@@ -95,7 +94,6 @@ def create_graph(dataset, root):
                 highest_node_diff = node_diff
             if edge_diff > highest_edge_diff:
                 highest_edge_diff = edge_diff
-            return 0
 
     print('------------------------------------------')
     num_correct = count-num_incorrect
@@ -106,6 +104,7 @@ def create_graph(dataset, root):
     print('Highest node diff: ', highest_node_diff)
     print('Highest edge diff: ', highest_edge_diff)
     print('------------------------------------------')
+    return G
 
 
 # create_graph('Non-phishing', '0x0000000000000000000000000000000000000000')


### PR DESCRIPTION
Graph was being returned after every successful expansion because of misplacement.